### PR TITLE
Check Network on Request

### DIFF
--- a/Libraries/Network/RCTNetInfo.m
+++ b/Libraries/Network/RCTNetInfo.m
@@ -43,6 +43,7 @@ static NSString *const RCTReachabilityStateCell = @"cell";
   NSString *_effectiveConnectionType;
   NSString *_statusDeprecated;
   NSString *_host;
+  BOOL _isObserving;
 }
 
 RCT_EXPORT_MODULE()
@@ -50,6 +51,59 @@ RCT_EXPORT_MODULE()
 static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info)
 {
   RCTNetInfo *self = (__bridge id)info;
+  if ([self setReachabilityStatus:flags] && self->_isObserving) {
+    [self sendEventWithName:@"networkStatusDidChange" body:@{@"connectionType": self->_connectionType,
+                                                             @"effectiveConnectionType": self->_effectiveConnectionType,
+                                                             @"network_info": self->_statusDeprecated}];
+  }
+}
+
+#pragma mark - Lifecycle
+
+- (instancetype)initWithHost:(NSString *)host
+{
+  RCTAssertParam(host);
+  RCTAssert(![host hasPrefix:@"http"], @"Host value should just contain the domain, not the URL scheme.");
+
+  if ((self = [self init])) {
+    _host = [host copy];
+  }
+  return self;
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"networkStatusDidChange"];
+}
+
+- (void)startObserving
+{
+  _isObserving = YES;
+  _connectionType = RCTConnectionTypeUnknown;
+  _effectiveConnectionType = RCTEffectiveConnectionTypeUnknown;
+  _statusDeprecated = RCTReachabilityStateUnknown;
+  [self setupReachability];
+}
+
+- (void)stopObserving
+{
+  _isObserving = NO;
+  if (_reachability) {
+    SCNetworkReachabilityUnscheduleFromRunLoop(_reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    CFRelease(_reachability);
+  }
+}
+
+- (void)setupReachability
+{
+  _reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, _host.UTF8String ?: "apple.com");
+  SCNetworkReachabilityContext context = { 0, ( __bridge void *)self, NULL, NULL, NULL };
+  SCNetworkReachabilitySetCallback(_reachability, RCTReachabilityCallback, &context);
+  SCNetworkReachabilityScheduleWithRunLoop(_reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+}
+
+- (BOOL)setReachabilityStatus:(SCNetworkReachabilityFlags)flags
+{
   NSString *connectionType = RCTConnectionTypeUnknown;
   NSString *effectiveConnectionType = RCTEffectiveConnectionTypeUnknown;
   NSString *status = RCTReachabilityStateUnknown;
@@ -98,47 +152,10 @@ static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
     self->_connectionType = connectionType;
     self->_effectiveConnectionType = effectiveConnectionType;
     self->_statusDeprecated = status;
-    [self sendEventWithName:@"networkStatusDidChange" body:@{@"connectionType": connectionType,
-                                                             @"effectiveConnectionType": effectiveConnectionType,
-                                                             @"network_info": status}];
+    return YES;
   }
-}
-
-#pragma mark - Lifecycle
-
-- (instancetype)initWithHost:(NSString *)host
-{
-  RCTAssertParam(host);
-  RCTAssert(![host hasPrefix:@"http"], @"Host value should just contain the domain, not the URL scheme.");
-
-  if ((self = [self init])) {
-    _host = [host copy];
-  }
-  return self;
-}
-
-- (NSArray<NSString *> *)supportedEvents
-{
-  return @[@"networkStatusDidChange"];
-}
-
-- (void)startObserving
-{
-  _connectionType = RCTConnectionTypeUnknown;
-  _effectiveConnectionType = RCTEffectiveConnectionTypeUnknown;
-  _statusDeprecated = RCTReachabilityStateUnknown;
-  _reachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, _host.UTF8String ?: "apple.com");
-  SCNetworkReachabilityContext context = { 0, ( __bridge void *)self, NULL, NULL, NULL };
-  SCNetworkReachabilitySetCallback(_reachability, RCTReachabilityCallback, &context);
-  SCNetworkReachabilityScheduleWithRunLoop(_reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-}
-
-- (void)stopObserving
-{
-  if (_reachability) {
-    SCNetworkReachabilityUnscheduleFromRunLoop(_reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-    CFRelease(_reachability);
-  }
+  
+  return NO;
 }
 
 #pragma mark - Public API
@@ -146,6 +163,8 @@ static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 RCT_EXPORT_METHOD(getCurrentConnectivity:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {
+  [self setupReachability];
+  CFRelease(_reachability);
   resolve(@{@"connectionType": _connectionType ?: RCTConnectionTypeUnknown,
             @"effectiveConnectionType": _effectiveConnectionType ?: RCTEffectiveConnectionTypeUnknown,
             @"network_info": _statusDeprecated ?: RCTReachabilityStateUnknown});


### PR DESCRIPTION
This is fixing #8615.  The problem was that, on initialization, the _connectionType variable was still set to its default value of RCTConnectionTypeUnknown.  The exposed API method did nothing to determine this unless a subscription had be established and then the method would simply return the last reported value.  Instead, the exposed oneshot API call now actually checks the connection status through the same methods as the subscription and updates RCTNetInfo’s values before returning.

In order to avoid reporting events without a subscription, a flag is set and unset on calls to start/stopObserving.